### PR TITLE
Add root prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Next, add the following in ```app/filesystems.php```:
     'dropbox' => [
         'driver' => 'dropbox',
         'token'  => env('DROPBOX_TOKEN'),
+        'path_prefix' => env('DROPBOX_PATH_PREFIX', ''),
     ],
 
 ],
@@ -48,7 +49,10 @@ Next, add the following in ```app/filesystems.php```:
 Then, in your ```.env``` file:
 ```
 DROPBOX_TOKEN=your_access_token
+DROPBOX_PATH_PREFIX=path/to/folder
 ```
+
+The path_prefix is an optional setting to make the app use a specific folder in the dropbox app as the root folder for the laravel disk. If you omit it the root folder of the dropbox app will be used.
 
 **Dealing with Dropbox for the first time? Here's the [link](https://www.dropbox.com/developers/apps/create) to create your first application and generate your access token.**
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -16,9 +16,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             // which is in charge of making requests to the service.
             $client = new \Spatie\Dropbox\Client($config['token']);
 
+            //Specify a root path for the dropbox adapter
+            $pathPrefix = isset($config['path_prefix']) ? $config['path_prefix'] : '';
+
             // Let's teach Flysystem to interact with Dropdox,
             // thanks to an adapter made by Spatie as usual.
-            $adapter = new \Spatie\FlysystemDropbox\DropboxAdapter($client);
+            $adapter = new \Spatie\FlysystemDropbox\DropboxAdapter($client, $pathPrefix);
 
             // Then, we return a new Flysystem instance
             // initialized with the Dropbox adapter.

--- a/tests/DropboxDriverTest.php
+++ b/tests/DropboxDriverTest.php
@@ -14,4 +14,23 @@ class DropboxDriverTest extends TestCase
         // Dropbox, since spatie/flysystem-dropbox does it.
         $this->assertInstanceOf(Illuminate\Filesystem\FilesystemAdapter::class, Storage::disk('dropbox'));
     }
+
+    /** @test */
+    public function it_specifes_a_path_prefix_for_dropbox()
+    {
+        config(['filesystems.disks.dropbox.token' => '']);
+        config(['filesystems.disks.dropbox.path_prefix' => 'path/to/rootFolder']);
+
+        $adapter = Storage::disk('dropbox')->getAdapter();
+        $this->assertEquals('path/to/rootFolder/', $adapter->getPathPrefix());
+    }
+
+    /** @test */
+    public function it_allows_for_absence_of_path_prefix()
+    {
+        config(['filesystems.disks.dropbox.token' => '']);
+
+        $adapter = Storage::disk('dropbox')->getAdapter();
+        $this->assertNull($adapter->getPathPrefix());
+    }
 }


### PR DESCRIPTION
This PR is to allow someone to specify the root folder that the file system uses within the dropbox app.

When creating the entry in the config/filesystems.php file, you just need to add
```
'path_prefix' => env('DROPBOX_PATH_PREFIX', ''),
```
to set the root folder.